### PR TITLE
Add Atom plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ python -m dg <<< "print 'Hello, World!'"
  * [Sublime Text and TextMate bundle](https://github.com/pyos/dg-textmate)
  * [GEdit/GtkSourceView syntax definition](https://github.com/pyos/dg-gedit)
  * [vim plugin](https://github.com/rubik/vim-dg) (courtesy of [Michele Lacchia](https://github.com/rubik))
+ * [Atom syntax](https://atom.io/packages/language-dg) (by [Ale](https://github.com/iamale))
 
 ### To-do
 


### PR DESCRIPTION
I've converted the TextMate bundle. It's probably a bit off, but is OK anyways.

Maybe something like [MagicPython](https://github.com/MagicStack/MagicPython) would be a better approach (they compile the TextMate / Sublime bundle and the Atom plugin from a unified YAML file)?..